### PR TITLE
Switch from MIPI SOAP to REST API

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 
 Previous explorations of the data have shown that historical trends in LDZ gas demand do not change significantly. We have therefor chose to limit historical data to the period from January 2019 up to November 2022. 
 
-If you managed to create your python environment as per the instructions in the main _README.md_ then you are ready to now also collect the data. Simply run `python src/get_data.py` and it will gather the necessary datasets and place them in the **data** folder.
+If you managed to create your python environment as per the instructions in the main _README.md_ then you are ready to now also collect the data. Simply run `python -m get_data` and it will gather the necessary datasets and place them in the **data** folder.
 
 You can adjust the time periods for which to download data by changing the dates in `get_data.py` (line 132-133).
 

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -14,7 +14,7 @@ def evaluate_models(predictions, actuals):
         )
         .groupby("MODEL")
         .apply(lambda df: calculate_metrics(df))
-        .reset_index()        
+        .reset_index()
     )
 
     return result
@@ -24,4 +24,4 @@ def calculate_metrics(input_data):
     mae = mean_absolute_error(input_data["LDZ"], input_data["PREDICTIONS"])
     mape = mean_absolute_percentage_error(input_data["LDZ"], input_data["PREDICTIONS"])
 
-    return pd.Series({"MAE":mae, "MAPE":mape})
+    return pd.Series({"MAE": mae, "MAPE": mape})

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -50,7 +50,7 @@ def get_cwv_from_mipi(output_dir, from_date, to_date):
         if len(data) > 0:
             cwvs_list.append(data)
     
-    if len(cwvs) > 0:
+    if len(cwvs_list) > 0:
         cwvs = pd.concat(cwvs_list)
         cwvs["LDZ"] = cwvs["PublicationName"].str.slice(-8, -6)
         df = cwvs.drop(columns="PublicationName")

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -2,11 +2,8 @@ import logging
 import datetime as dt
 import pandas as pd
 from os import path
-from requests import Session
 
-from zeep import Client
-from zeep.helpers import serialize_object
-from zeep.transports import Transport
+from src.mipi import get_mipi_data
 
 
 logger = logging.getLogger(__name__)
@@ -49,9 +46,8 @@ def get_cwv_from_mipi(output_dir, from_date, to_date):
     cwvs = get_mipi_data(CWV_DATA_ITEMS, from_date, to_date)
 
     if len(cwvs) > 0:
-        df = pd.concat(cwvs)
-        df["LDZ"] = df["DATA_ITEM"].str.slice(-8, -6)
-        df = df.drop(columns="DATA_ITEM")
+        cwvs["LDZ"] = cwvs["PublicationName"].str.slice(-8, -6)
+        df = cwvs.drop(columns="PublicationName")
         df.to_csv(
             path.join(output_dir, f"cwv_data_{dt.datetime.now().strftime(FORMAT)}.csv"),
             index=False,
@@ -71,60 +67,16 @@ def get_gas_actuals_from_mipi(output_dir, from_date, to_date):
     """
     actual_data = get_mipi_data(GAS_ACTUAL_DATA_ITEMS, from_date, to_date)
     if len(actual_data) > 0:
-        df = pd.concat(actual_data)
-        df = df.rename(columns={"DATA_ITEM": "TYPE"})
+        df = actual_data.rename(columns={"PublicationName": "TYPE"})
         df["Value"] = pd.to_numeric(df["Value"])
         df.to_csv(
-            path.join(output_dir, f"gas_actuals_{dt.datetime.now().strftime(FORMAT)}.csv"),
+            path.join(
+                output_dir, f"gas_actuals_{dt.datetime.now().strftime(FORMAT)}.csv"
+            ),
             index=False,
         )
     else:
         logger.warn("No Actuals Data Returned")
-
-
-def get_mipi_data(item_names, from_date, to_date):
-    """Retrieve data from MIPI for the given data sets (item names) and between the given dates
-
-    Args:
-        item_names (list): List of strings corresponding to datasets in MIPI
-        from_date (str): Lower bound for the applicable date of the dataset, yyyy-mm-dd format
-        to_date (str): Upper bound for the applicable date of the dataset, yyyy-mm-dd format
-
-    Returns:
-        list: A list of DataFrames, each DataFrame represents a dataset
-    """
-    session = Session()
-    client = Client(MIPI_URL, transport=Transport(session=session))
-
-    body = {
-        "LatestFlag": "Y",
-        "ApplicableForFlag": "Y",
-        "FromDate": from_date,
-        "ToDate": to_date,
-        "DateType": "GASDAY",
-    }
-    result = []
-    for item in item_names:
-
-        logger.debug(
-            f"MIPI LDZ Actual : Gathering {item} data, from {from_date} to {to_date}",
-        )
-
-        body["PublicationObjectNameList"] = {"string": item}
-        r = client.service.GetPublicationDataWM(body)
-        if r is not None:
-            data_dic = [
-                serialize_object(d)
-                for d in r[0].PublicationObjectData["CLSPublicationObjectDataBE"]
-            ]
-            df = pd.DataFrame(data=data_dic, columns=data_dic[0].keys())
-            df["DATA_ITEM"] = item
-            result.append(df)
-        else:
-            logger.warning(f"No Data for: {item}")
-
-    return result
-
 
 
 if __name__ == "__main__":

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -43,9 +43,15 @@ def get_cwv_from_mipi(output_dir, from_date, to_date):
         from_date (str): Lower bound for the applicable date of the dataset, yyyy-mm-dd format
         to_date (str): Upper bound for the applicable date of the dataset, yyyy-mm-dd format
     """
-    cwvs = get_mipi_data(CWV_DATA_ITEMS, from_date, to_date)
-
+    cwvs_list = []
+    # Have to get the data for each LDZ separately as the requested data is more than the allowed threshold
+    for item in CWV_DATA_ITEMS:
+        data = get_mipi_data([item], from_date, to_date)
+        if len(data) > 0:
+            cwvs_list.append(data)
+    
     if len(cwvs) > 0:
+        cwvs = pd.concat(cwvs_list)
         cwvs["LDZ"] = cwvs["PublicationName"].str.slice(-8, -6)
         df = cwvs.drop(columns="PublicationName")
         df.to_csv(

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -53,7 +53,7 @@ def get_cwv_from_mipi(output_dir, from_date, to_date):
             index=False,
         )
     else:
-        logger.warning(f"No CWV Data Available")
+        logger.warning("No CWV Data Available")
 
 
 def get_gas_actuals_from_mipi(output_dir, from_date, to_date):
@@ -76,7 +76,7 @@ def get_gas_actuals_from_mipi(output_dir, from_date, to_date):
             index=False,
         )
     else:
-        logger.warn("No Actuals Data Returned")
+        logger.warning("No Actuals Data Returned")
 
 
 if __name__ == "__main__":

--- a/src/mipi.py
+++ b/src/mipi.py
@@ -1,0 +1,110 @@
+import pandas as pd
+import requests
+
+MIPI_CATALOG_URL = (
+    "https://api.nationalgas.com/operationaldata/v1/publications/catalogue"
+)
+
+MIPI_DATA_URL = "https://api.nationalgas.com/operationaldata/v1/publications/gasday"
+
+
+def process_subcategories(cat_item: dict, parent_category: str) -> list:
+    """
+    Recursively processes category and subcategory entries from a catalogue item.
+    This function traverses through a nested category structure and extracts catalogue entries,
+    maintaining the hierarchical relationship between categories and subcategories.
+    Args:
+        cat_item (dict): A dictionary containing either catalogueEntries or subCategory items
+        parent_category (str): The parent category name, used to build the category hierarchy path
+    Returns:
+        list: A list of dictionaries containing processed catalogue entries with their following keys:
+            - name: The name of the catalogue entry
+            - publicationId: The publication ID of the entry
+            - category: The immediate category name
+            - subcategory: The full category path including parent categories
+    """
+    result = []
+    if "catalogueEntries" in cat_item:
+        for entry in cat_item["catalogueEntries"]:
+            result.append(
+                {
+                    "name": entry["name"],
+                    "publicationId": entry["publicationId"],
+                    "category": cat_item["name"],
+                    "subcategory": parent_category,
+                }
+            )
+        return result
+
+    if "subCategory" in cat_item:
+        for subcat in cat_item["subCategory"]:
+            new_parent = (
+                f"{parent_category}/{subcat['name']}"
+                if parent_category
+                else subcat["name"]
+            )
+            result.extend(process_subcategories(subcat, new_parent))
+        return result
+
+
+def get_mipi_catalogue_items() -> pd.DataFrame:
+    """
+    Retrieves and processes MIPI catalogue items from an API endpoint.
+    This function fetches the MIPI catalogue data from a predefined URL, processes the
+    hierarchical category structure, and converts it into a pandas DataFrame.
+    Returns:
+        pandas.DataFrame: A DataFrame containing the processed MIPI catalogue items
+            with their respective category information.
+    Raises:
+        requests.exceptions.RequestException: If there's an error fetching data from the API
+        KeyError: If the expected 'data' key is not found in the API response
+        JSONDecodeError: If the API response cannot be parsed as JSON
+    """
+    response = requests.get(MIPI_CATALOG_URL)
+    catalogue = response.json()["data"]
+    items = []
+    for category in catalogue:
+        items.extend(process_subcategories(category, ""))
+
+    return pd.DataFrame(items)
+
+
+def get_mipi_data(names: list, from_date: str, to_date: str) -> pd.DataFrame:
+    """
+    Retrieves MIPI data for a specific publication between given dates.
+
+    Args:
+        names (list): Names of the publications to fetch
+        from_date (str): Start date in YYYY-MM-DD format
+        to_date (str): End date in YYYY-MM-DD format
+
+    Returns:
+        pd.DataFrame: DataFrame containing the publication data with timestamps and values
+    """
+    # Get catalogue and find publication IDs
+    catalogue_df = get_mipi_catalogue_items()
+    pub_ids = catalogue_df[catalogue_df["name"].isin(names)]["publicationId"].tolist()
+
+    # Prepare and send request
+    payload = {
+        "fromDate": from_date,
+        "toDate": to_date,
+        "publicationIds": pub_ids,
+        "latestValue": "Y",
+    }
+
+    response = requests.post(MIPI_DATA_URL, json=payload)
+    data = response.json()
+
+    # Extract publications data and create DataFrame
+    result = []
+    for item in data:
+        pub_name = item["publicationName"]
+        for pub in item["publications"]:
+            pub["publicationName"] = pub_name
+            result.append(pub)
+
+    # for backwards compatibility with the SOAP API all headers are capitalised
+    df = pd.DataFrame(result)
+    df.columns = [col[0].upper() + col[1:] for col in df.columns]
+    return df

--- a/src/mipi.py
+++ b/src/mipi.py
@@ -1,5 +1,8 @@
 import pandas as pd
 import requests
+import logging
+
+logger = logging.getLogger(__name__)
 
 MIPI_CATALOG_URL = (
     "https://api.nationalgas.com/operationaldata/v1/publications/catalogue"
@@ -61,6 +64,10 @@ def get_mipi_catalogue_items() -> pd.DataFrame:
         JSONDecodeError: If the API response cannot be parsed as JSON
     """
     response = requests.get(MIPI_CATALOG_URL)
+    if response.status_code != 200:
+        logger.error(f"API request failed with status code {response.status_code}. Error: {response.text}")
+        return pd.DataFrame()
+    
     catalogue = response.json()["data"]
     items = []
     for category in catalogue:
@@ -94,8 +101,12 @@ def get_mipi_data(names: list, from_date: str, to_date: str) -> pd.DataFrame:
     }
 
     response = requests.post(MIPI_DATA_URL, json=payload)
-    data = response.json()
+    
+    if response.status_code != 200:
+        logger.error(f"API request failed with status code {response.status_code}. Error: {response.text}")
+        return pd.DataFrame()
 
+    data = response.json()
     # Extract publications data and create DataFrame
     result = []
     for item in data:

--- a/src/prepare_data.py
+++ b/src/prepare_data.py
@@ -74,23 +74,23 @@ def add_christmas_bank_holiday(input_data):
         input_data (pandas DataFrame): A DataFrame with dates on the index
 
     Returns:
-        pandas DataFrame: A DataFrame with an additional CHRISTMAS_DAY, NEW_YEARS_DAY, NEW_YEARS_EVE 
+        pandas DataFrame: A DataFrame with an additional CHRISTMAS_DAY, NEW_YEARS_DAY, NEW_YEARS_EVE
         and BOXING_DAY column. Values are 0 (= no bank holiday) and 1 (= bank holiday) values
     """
     result = input_data.copy()
 
     result["M"] = result.index.month
     result["D"] = result.index.day
-    result["CHRISTMAS_DAY"] = result["NEW_YEARS_DAY"] = result["NEW_YEARS_EVE"] = result[
-        "BOXING_DAY"
-    ] = 0
+    result["CHRISTMAS_DAY"] = result["NEW_YEARS_DAY"] = result[
+        "NEW_YEARS_EVE"
+    ] = result["BOXING_DAY"] = 0
     result.loc[(result["M"] == 12) & (result["D"] == 25), "CHRISTMAS_DAY"] = 1
     result.loc[(result["M"] == 1) & (result["D"] == 1), "NEW_YEARS_DAY"] = 1
     result.loc[(result["M"] == 12) & (result["D"] == 31), "NEW_YEARS_EVE"] = 1
     result.loc[(result["M"] == 12) & (result["D"] == 26), "BOXING_DAY"] = 1
 
     result = result.drop(columns=["M", "D"])
-    
+
     return result
 
 
@@ -107,7 +107,9 @@ def add_workday(input_data):
     result = input_data.copy()
 
     cal = UnitedKingdom()
-    result["WORK_DAY"] = result.index.to_series().apply(lambda x: 1 if cal.is_working_day(x) else 0)
+    result["WORK_DAY"] = result.index.to_series().apply(
+        lambda x: 1 if cal.is_working_day(x) else 0
+    )
 
     return result
 

--- a/src/train.py
+++ b/src/train.py
@@ -34,7 +34,7 @@ def train_glm(target, features):
 
     model = LinearRegression()
     model.fit(X, y)
-    
+
     return model, predictions
 
 
@@ -58,7 +58,6 @@ def tss_cross_val_predict(X, y, model, min_train=7, weighted=False):
     tscv = TimeSeriesSplit(n_splits=nsplits)
 
     for train_index, test_index in tscv.split(X):
-
         if len(train_index) < min_train:
             continue
 
@@ -363,12 +362,11 @@ def exp_decay_sample_weights(df, alpha=0.943):
     df = df.copy()
     df = df.sort_index(ascending=True)
     df = df.reset_index()
-    df['sample_weight'] = alpha ** df.index[::-1]
+    df["sample_weight"] = alpha ** df.index[::-1]
     return df.sample_weight.values
 
 
 def train_weighted_ldz_wd_model(target, features):
-
     logger.info("Training weighted linear model with CWV and Weekend feature")
     X = features[["CWV", "WEEKEND"]].dropna()
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,9 @@
 import os
 
+
 # from https://stackoverflow.com/questions/11130156/suppress-stdout-stderr-print-from-python-functions
 class suppress_stdout_stderr(object):
-    '''
+    """
     A context manager for doing a "deep suppression" of stdout and stderr in
     Python, i.e. will suppress all print, even if the print originates in a
     compiled C/Fortran sub-function.
@@ -10,7 +11,8 @@ class suppress_stdout_stderr(object):
     to stderr just before a script exits, and after the context manager has
     exited (at least, I think that is why it lets exceptions through).
 
-    '''
+    """
+
     def __init__(self):
         # Open a pair of null files
         self.null_fds = [os.open(os.devnull, os.O_RDWR) for x in range(2)]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -6,25 +6,26 @@ from src.evaluate import evaluate_models
 
 def test_evaluate_models_one_model():
     mock_predictions = pd.DataFrame(
-        {"GLM":[1, 2, 3, 4, 5, 6]}, index=pd.date_range("2022-08-01", "2022-08-06")
+        {"GLM": [1, 2, 3, 4, 5, 6]}, index=pd.date_range("2022-08-01", "2022-08-06")
     )
     actuals = pd.DataFrame(
-        {"LDZ": np.arange(7,1, step=-1)}, index=pd.date_range("2022-08-01", "2022-08-06")
+        {"LDZ": np.arange(7, 1, step=-1)},
+        index=pd.date_range("2022-08-01", "2022-08-06"),
     )
 
     result = evaluate_models(mock_predictions, actuals)
-    desired_result = pd.DataFrame(
-        {"MODEL": ["GLM"], "MAE": [3.0], "MAPE": [0.765079]}
-    )
+    desired_result = pd.DataFrame({"MODEL": ["GLM"], "MAE": [3.0], "MAPE": [0.765079]})
     assert_frame_equal(result, desired_result)
 
 
 def test_evaluate_models_two_models():
     mock_predictions = pd.DataFrame(
-        {"GLM":[1, 2, 3, 4, 5, 6], "DIFF":[4, 5, 3, 1, 8, 6]}, index=pd.date_range("2022-08-01", "2022-08-06")
+        {"GLM": [1, 2, 3, 4, 5, 6], "DIFF": [4, 5, 3, 1, 8, 6]},
+        index=pd.date_range("2022-08-01", "2022-08-06"),
     )
     actuals = pd.DataFrame(
-        {"LDZ": np.arange(7,1, step=-1)}, index=pd.date_range("2022-08-01", "2022-08-06")
+        {"LDZ": np.arange(7, 1, step=-1)},
+        index=pd.date_range("2022-08-01", "2022-08-06"),
     )
 
     result = evaluate_models(mock_predictions, actuals)

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -2,73 +2,19 @@ import logging
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import src.get_data
-from src.get_data import get_cwv_from_mipi, get_gas_actuals_from_mipi, get_mipi_data
-
-
-def test_get_mipi_data_no_data(monkeypatch, caplog):
-    caplog.set_level(logging.DEBUG)
-
-    class MockService:
-        def GetPublicationDataWM(self, body):
-            return None
-
-    class MockClient:
-        service = MockService()
-
-        def __init__(self, url, transport) -> None:
-            pass
-
-    monkeypatch.setattr(src.get_data, "Client", MockClient)
-
-    result = get_mipi_data(["One"], "2022-01-01", "2022-01-02")
-    assert result == []
-
-    assert len(caplog.messages) == 2
-    assert (
-        caplog.messages[0]
-        == "MIPI LDZ Actual : Gathering One data, from 2022-01-01 to 2022-01-02"
-    )
-    assert caplog.messages[1] == "No Data for: One"
-
-
-def test_get_mipi_data(monkeypatch):
-    mock_data = [{"One": 1.0, "Two": 2.0}, {"One": 3.0, "Two": 4.0}]
-
-    class MockResponse:
-        PublicationObjectData = {"CLSPublicationObjectDataBE": mock_data}
-
-    class MockService:
-        def GetPublicationDataWM(self, body):
-            return [MockResponse()]
-
-    class MockClient:
-        service = MockService()
-
-        def __init__(self, url, transport) -> None:
-            pass
-
-    monkeypatch.setattr(src.get_data, "Client", MockClient)
-
-    result = get_mipi_data(["One"], "2022-01-01", "2022-01-02")
-    desired_result = pd.DataFrame(
-        {"One": [1.0, 3.0], "Two": [2.0, 4.0], "DATA_ITEM": ["One", "One"]}
-    )
-    assert len(result) == 1  # only 1 data item
-    assert_frame_equal(result[0], desired_result)
+from src.get_data import get_cwv_from_mipi, get_gas_actuals_from_mipi
 
 
 def test_get_cwv_from_mipi(monkeypatch):
-    mock_data = [
-        pd.DataFrame(
-            {
-                "DUMMY": [1.0, 2.0],
-                "DATA_ITEM": [
-                    "Composite Weather Variable, Actual, LDZ(EA), D+1",
-                    "Composite Weather Variable, Actual, LDZ(EM), D+1",
-                ],
-            }
-        )
-    ]
+    mock_data = pd.DataFrame(
+        {
+            "DUMMY": [1.0, 2.0],
+            "PublicationName": [
+                "Composite Weather Variable, Actual, LDZ(EA), D+1",
+                "Composite Weather Variable, Actual, LDZ(EM), D+1",
+            ],
+        }
+    )
 
     def mock_get_mipi_data(items, fromdt, todt):
         return mock_data
@@ -85,17 +31,15 @@ def test_get_cwv_from_mipi(monkeypatch):
 
 
 def test_get_gas_actuals_from_mipi(monkeypatch):
-    mock_data = [
-        pd.DataFrame(
-            {
-                "Value": ["1.0", "2.0"],
-                "DATA_ITEM": [
-                    "NTS Volume Offtaken, Industrial Offtake Total",
-                    "NTS Volume Offtaken, Interconnector Exports Total",
-                ],
-            }
-        )
-    ]
+    mock_data = pd.DataFrame(
+        {
+            "Value": ["1.0", "2.0"],
+            "PublicationName": [
+                "NTS Volume Offtaken, Industrial Offtake Total",
+                "NTS Volume Offtaken, Interconnector Exports Total",
+            ],
+        }
+    )
 
     def mock_get_mipi_data(items, fromdt, todt):
         return mock_data
@@ -109,4 +53,3 @@ def test_get_gas_actuals_from_mipi(monkeypatch):
 
     get_gas_actuals_from_mipi("", "", "")
     assert True
-

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -1,6 +1,4 @@
-import logging
 import pandas as pd
-from pandas.testing import assert_frame_equal
 import src.get_data
 from src.get_data import get_cwv_from_mipi, get_gas_actuals_from_mipi
 

--- a/tests/test_mipi.py
+++ b/tests/test_mipi.py
@@ -1,0 +1,45 @@
+from src.mipi import process_subcategories, get_mipi_catalogue_items
+
+
+def test_process_subcategories_direct_entries():
+    cat_item_direct = {
+        "name": "TestCategory",
+        "catalogueEntries": [
+            {"name": "Entry1", "publicationId": "pub1"},
+            {"name": "Entry2", "publicationId": "pub2"},
+        ],
+    }
+    result_direct = process_subcategories(cat_item_direct, "ParentCat")
+    assert len(result_direct) == 2
+    assert result_direct[0] == {
+        "name": "Entry1",
+        "publicationId": "pub1",
+        "category": "TestCategory",
+        "subcategory": "ParentCat",
+    }
+    assert result_direct[1] == {
+        "name": "Entry2",
+        "publicationId": "pub2",
+        "category": "TestCategory",
+        "subcategory": "ParentCat",
+    }
+
+
+def test_process_subcategories_nested_structure():
+    cat_item_sub = {
+        "name": "MainCategory",
+        "subCategory": [
+            {
+                "name": "SubCategory",
+                "catalogueEntries": [{"name": "SubEntry1", "publicationId": "pub3"}],
+            }
+        ],
+    }
+    result_sub = process_subcategories(cat_item_sub, "")
+    assert len(result_sub) == 1
+    assert result_sub[0] == {
+        "name": "SubEntry1",
+        "publicationId": "pub3",
+        "category": "SubCategory",
+        "subcategory": "SubCategory",
+    }

--- a/tests/test_mipi.py
+++ b/tests/test_mipi.py
@@ -1,3 +1,6 @@
+import requests
+import pandas as pd
+from pandas.testing import assert_frame_equal
 from src.mipi import process_subcategories, get_mipi_catalogue_items
 
 
@@ -43,3 +46,57 @@ def test_process_subcategories_nested_structure():
         "category": "SubCategory",
         "subcategory": "SubCategory",
     }
+
+
+def test_get_mipi_catalogue_items(monkeypatch):
+    mock_response = {
+        "data": [
+            {
+                "name": "Category1",
+                "catalogueEntries": [
+                    {"name": "Entry1", "publicationId": "pub1"}
+                ]
+            },
+            {
+                "name": "Category2",
+                "subCategory": [
+                    {
+                        "name": "SubCat",
+                        "catalogueEntries": [
+                            {"name": "Entry2", "publicationId": "pub2"}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    class MockResponse:
+        def __init__(self):
+            self.status_code = 200
+
+        def json(self):
+            return mock_response
+
+    def mock_get(*args, **kwargs):
+        return MockResponse()
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    result = get_mipi_catalogue_items()
+    expected_df = pd.DataFrame([
+        {
+            "name": "Entry1",
+            "publicationId": "pub1",
+            "category": "Category1",
+            "subcategory": ""
+        },
+        {
+            "name": "Entry2",
+            "publicationId": "pub2",
+            "category": "SubCat",
+            "subcategory": "SubCat"
+        }
+    ])
+    
+    assert_frame_equal(result, expected_df)

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -10,7 +10,7 @@ from src.prepare_data import (
     prepare_cwv_diff,
     add_workday,
     add_christmas_bank_holiday,
-    add_weekend_indicator
+    add_weekend_indicator,
 )
 
 
@@ -91,7 +91,6 @@ def test_prepare_cwv(monkeypatch):
 
 
 def test_prepare_gas_demand_diff(monkeypatch):
-
     mock_data = pd.DataFrame(
         {
             "INDUSTRIAL": [1.0] * 4,
@@ -121,7 +120,6 @@ def test_prepare_gas_demand_diff(monkeypatch):
 
 
 def test_prepare_cwv_diff(monkeypatch):
-
     mock_data = pd.DataFrame(
         {"CWV": [1.0, 2, 4, 10]},
         index=pd.DatetimeIndex(
@@ -156,6 +154,7 @@ def test_add_workday():
 
     assert_frame_equal(result, desired_result)
 
+
 def test_add_christmas_bank_holiday():
     mock_data = pd.DataFrame(
         {"One": [1] * 10}, index=pd.date_range("2022-12-24", periods=10, freq="D")
@@ -167,8 +166,8 @@ def test_add_christmas_bank_holiday():
     desired_result["CHRISTMAS_DAY"] = [0, 1] + [0] * 8
     desired_result["NEW_YEARS_DAY"] = [0] * 8 + [1, 0]
     desired_result["NEW_YEARS_EVE"] = [0] * 7 + [1, 0, 0]
-    desired_result["BOXING_DAY"] = [0, 0, 1] + [0] * 7   
-        
+    desired_result["BOXING_DAY"] = [0, 0, 1] + [0] * 7
+
     assert_frame_equal(result, desired_result)
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -11,7 +11,7 @@ from src.train import (
     add_average_demand_by_month_day,
     train_glm,
     train_ldz_stack_model,
-    exp_decay_sample_weights
+    exp_decay_sample_weights,
 )
 
 
@@ -213,7 +213,6 @@ def test_train_ldz_diff():
 
 
 def test_get_ldz_match_predictions_basic():
-
     dates = pd.date_range("2023-01-29", periods=40, freq="D")
 
     mock_target = pd.DataFrame(
@@ -246,7 +245,6 @@ def test_get_ldz_match_predictions_basic():
 
 
 def test_get_ldz_match_predictions_with_averages(monkeypatch):
-
     dates = pd.date_range("2023-01-29", periods=40, freq="D")
 
     mock_target = pd.DataFrame(
@@ -438,7 +436,6 @@ def test_train_ldz_stack_model():
     )
 
     assert_series_equal(result, desired_result)
-
 
 
 def test_exp_decay_sample_weights():


### PR DESCRIPTION
I've removed the functionality to pull from the SOAP API and replaced it with the REST API. All code is in **mipi.py**. 

The main difference is that the REST API works with publication ids so I had to pull the entire catalogue and then translate the data items to publication ids. 

Also there's a data volume threshold on the API so you can't pull too much data. For the CWV I had to process each zone separately.